### PR TITLE
Add Screenshot Plugin configuration

### DIFF
--- a/plugins/screenshot-plugin.json
+++ b/plugins/screenshot-plugin.json
@@ -1,0 +1,5 @@
+{
+    "repository_owner": "bottymcgee",
+    "repository_name": "Screenshot-Plugin",
+    "asset_sha": "sha256:8c3f9463709820358a8fca9f571cea541d91a7839f9848113509d1b19a76f6b4"
+} 


### PR DESCRIPTION
   This PR adds the Screenshot Plugin to the HighLite Plugin Hub.
   
   Plugin Details:
   - Repository: bottymcgee/Screenshot-Plugin
   - SHA256: 8c3f9463709820358a8fca9f571cea541d91a7839f9848113509d1b19a76f6b4
   
   Features:
   - Screenshot button in titlebar
   - Keyboard shortcut (Ctrl+Shift+S)
   - Audio feedback
   - Customizable settings
   - Automatic file organization