### PR TITLE
playerTags 1.1.1. Styling and example conf bug fixes. Rename display …

### DIFF
--- a/plugins/player-tagger.json
+++ b/plugins/player-tagger.json
@@ -1,5 +1,8 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "PlayerTags",
-    "asset_sha": "sha256:296b22b9adf584ec7ee506c9002ead9264602a35ac68d81d1c2d21d0e5b2a674"
+    "asset_sha": "sha256:f1f215048d87bfe0a04c69951841d58dfe1889b9afb963533d15ae09fa029fa4",
+    "display_name": "Clan Tags",
+    "display_author": "0rangeYouGlad",
+    "display_description":"Tags for clans that display in chat and player nameplates"
 }


### PR DESCRIPTION
…name to Clan Tags to avoid confusion.

Adds https://github.com/Ralane/PlayerTags/releases/tag/v1.1.1