### PR TITLE
QuickActionTooltips v2.1.2. Also update display fields for other 0rangeYouGlad plugins

### DIFF
--- a/plugins/custom-cursor.json
+++ b/plugins/custom-cursor.json
@@ -1,5 +1,8 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "CustomCursor",
-    "asset_sha": "sha256:2b54afcf4c678fb5458357c057412819dba885712fa0c50576ec535800c02c63"
+    "asset_sha": "sha256:2b54afcf4c678fb5458357c057412819dba885712fa0c50576ec535800c02c63",
+    "display_name": "Custom Cursors",
+    "display_author": "0rangeYouGlad",
+    "display_description":"Fancy new cursors, with presets using Highspell icons"
 }

--- a/plugins/quick-action-mouse-tooltip.json
+++ b/plugins/quick-action-mouse-tooltip.json
@@ -1,7 +1,7 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "QuickActionMouseTooltip",
-    "asset_sha": "sha256:f3d409b3dfbdc74e3813b93ef33c44cb227f7810c343c42b6c87b9a197eaed93",
+    "asset_sha": "sha256:1b0451cb101614c9d22dace53dbcc2314d20559b813f977c9ea3b6a17e2293a0",
     "display_name": "Quick-Action Tooltip",
     "display_author": "0rangeYouGlad",
     "display_description":"Shows the current quick action (what you're about to click) as a tooltip"

--- a/plugins/quick-action-mouse-tooltip.json
+++ b/plugins/quick-action-mouse-tooltip.json
@@ -1,5 +1,8 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "QuickActionMouseTooltip",
-    "asset_sha": "sha256:cf5ac6ad7e7731ff318b930bcdf08913d3b51f6dcbcd4b783e78604e4050734f"
+    "asset_sha": "sha256:cf5ac6ad7e7731ff318b930bcdf08913d3b51f6dcbcd4b783e78604e4050734f",
+    "display_name": "Quick-Action Tooltip",
+    "display_author": "0rangeYouGlad",
+    "display_description":"Shows the current quick action (what you're about to click) as a tooltip"
 }

--- a/plugins/quick-action-mouse-tooltip.json
+++ b/plugins/quick-action-mouse-tooltip.json
@@ -1,7 +1,7 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "QuickActionMouseTooltip",
-    "asset_sha": "sha256:1b0451cb101614c9d22dace53dbcc2314d20559b813f977c9ea3b6a17e2293a0",
+    "asset_sha": "sha256:68063e3aefad6cf673f2a7ddb744cf0da2d6986d29b736eae95d86382d5b4989",
     "display_name": "Quick-Action Tooltip",
     "display_author": "0rangeYouGlad",
     "display_description":"Shows the current quick action (what you're about to click) as a tooltip"

--- a/plugins/quick-action-mouse-tooltip.json
+++ b/plugins/quick-action-mouse-tooltip.json
@@ -1,7 +1,7 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "QuickActionMouseTooltip",
-    "asset_sha": "sha256:68063e3aefad6cf673f2a7ddb744cf0da2d6986d29b736eae95d86382d5b4989",
+    "asset_sha": "sha256:dac81ccc441dfaac36a53b390f97952371ef504d614f57b914b22e12aa05d273",
     "display_name": "Quick-Action Tooltip",
     "display_author": "0rangeYouGlad",
     "display_description":"Shows the current quick action (what you're about to click) as a tooltip"

--- a/plugins/quick-action-mouse-tooltip.json
+++ b/plugins/quick-action-mouse-tooltip.json
@@ -1,7 +1,7 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "QuickActionMouseTooltip",
-    "asset_sha": "sha256:cf5ac6ad7e7731ff318b930bcdf08913d3b51f6dcbcd4b783e78604e4050734f",
+    "asset_sha": "sha256:f3d409b3dfbdc74e3813b93ef33c44cb227f7810c343c42b6c87b9a197eaed93",
     "display_name": "Quick-Action Tooltip",
     "display_author": "0rangeYouGlad",
     "display_description":"Shows the current quick action (what you're about to click) as a tooltip"

--- a/plugins/tts-chat.json
+++ b/plugins/tts-chat.json
@@ -1,5 +1,8 @@
 {
     "repository_owner": "Ralane",
     "repository_name": "HighliteTtsChat",
-    "asset_sha": "sha256:4eedb1ae7e656ed45e1bdf08f21aa67e9ae6bc4e057f23228a6a553684f69480"
+    "asset_sha": "sha256:4eedb1ae7e656ed45e1bdf08f21aa67e9ae6bc4e057f23228a6a553684f69480",
+    "display_name": "TTS Chat",
+    "display_author": "0rangeYouGlad",
+    "display_description":"Text-to-speech for chat. Uses your system's available voice packs."
 }


### PR DESCRIPTION
Adds https://github.com/Ralane/QuickActionMouseTooltip/releases/tag/v2.1.2

Features:
- Major performance improvements by skipping updates when text is unchanged
- Add "Hide on Inventory" setting
- Add "Hide on Use With" setting
- Add "Hide on Bank" setting
- Add "Hide on Trades" setting
- Add "Hide on Spellbook" setting
- Add "Hide on Misc UI" setting
- Add "Hide on Shops" setting
- Add "Hide on Creation UI" setting

Bug fixes:
- Fix "Hide Walk Here" setting not saving correctly

Also updating the display name/author/description for other plugins not covered by another Pull Request. No code changes for these plugins.