### PR TITLE
Add iron-mode.json

### DIFF
--- a/plugins/iron-mode.json
+++ b/plugins/iron-mode.json
@@ -1,0 +1,9 @@
+{
+    "repository_owner": "BakaZora",
+    "repository_name": "highlite-plugins",
+    "asset_sha": "sha256:86eaa59f6fdc2a17f1e015f6684d122035a1c782c26dde7ae05aa295805c61be",
+    "display_name": "Iron Mode",
+    "display_author": "Zora",
+    "discord_id": "@BakaZora",
+    "display_description":"See yours and other players iron statuses in the chat, or try playing an iron yourself! Supports Iron, Hardcore, Ultimate, and Group Iron playstyles!"
+}


### PR DESCRIPTION
Adds Iron Mode plugin 

This plugin will take the users settings and POST them to a database via a cloud worker, as well as fetch users Iron Statuses from the same database. This is used to determine each players status so that helms can be shown correctly in the chat.

Other features include stopping other players from trading the player when Iron is enabled