### PR TITLE
Add: Iron Mode

### DIFF
--- a/plugins/iron-mode.json
+++ b/plugins/iron-mode.json
@@ -1,7 +1,7 @@
 {
     "repository_owner": "BakaZora",
     "repository_name": "highlite-plugins",
-    "asset_sha": "sha256:86eaa59f6fdc2a17f1e015f6684d122035a1c782c26dde7ae05aa295805c61be",
+    "asset_sha": "sha256:2cc81b25741bc45dc8913553d586e28c843c2d7f3ce7f740d5f817d638d6cfd0",
     "display_name": "Iron Mode",
     "display_author": "Zora",
     "discord_id": "@BakaZora",

--- a/plugins/iron-mode.json
+++ b/plugins/iron-mode.json
@@ -1,0 +1,9 @@
+{
+    "repository_owner": "BakaZora",
+    "repository_name": "highlite-plugins",
+    "asset_sha": "sha256:86eaa59f6fdc2a17f1e015f6684d122035a1c782c26dde7ae05aa295805c61be",
+    "display_name": "Iron Mode",
+    "display_author": "Zora",
+    "discord_id": "@BakaZora",
+    "display_description":"See yours and other players iron statuses in the chat, or try playing an iron yourself! Supports Iron, Hardcore, Ultimate, and Group Iron playstyles!"
+}


### PR DESCRIPTION
Iron Mode Plugin Features:
-Restricts trade to players through context based on whether the target is in a list of group mates
-Restricts trade from players unless trader is in players list of group mates
-Periodically sends user settings to api to store players iron status in a database
-Pulls (and caches) players iron statuses from chat messages, and inserts the appropriate helmet where applicable

Update from previous commit: Settings clean-up, code clean-up, bug fixes