### PR TITLE
delete treasure map helper

### DIFF
--- a/plugins/treasure-map-helper.json
+++ b/plugins/treasure-map-helper.json
@@ -1,5 +1,0 @@
-{
-    "repository_owner": "Oatelaus",
-    "repository_name": "highspell-treasure-map-helper",
-    "asset_sha": "sha256:521a27acea6f8bc409db4ae0a896cbb556833c77340f94dbcea816ed3cd5ff1a"
-}


### PR DESCRIPTION
The direction of the general HighSpell community was concerning but with staff members advocating for harmful activities such as gambling in game I no longer want to be associated with this game.