### PR TITLE
Release Sort Bank Items

### DIFF
--- a/plugins/sort-bank-items.json
+++ b/plugins/sort-bank-items.json
@@ -1,0 +1,8 @@
+{
+    "repository_owner": "Stark-Night",
+    "repository_name": "hs-sort-bank-items-plugin",
+    "asset_sha": "sha256:ff01799041aca73eec4fe275a93961d817e5143babc82b9b096ea4fd7fae0b5f",
+    "display_name": "Sort Bank Items",
+    "display_author": "Geeno",
+    "display_description": "Sort your bank items automatically."
+}


### PR DESCRIPTION
This plugin can sort bank items, as of v1.0.0 by internal ID and by in-game cost.