### PR TITLE
Added two plugins, ItemTags and MenuRGB

### DIFF
--- a/plugins/item-tags.json
+++ b/plugins/item-tags.json
@@ -1,0 +1,9 @@
+{
+  "repository_owner": "crispybittie",
+  "repository_name": "ItemTags",
+  "asset_sha": "sha256:df488f6f997bfcbf67bc42a7f09367776521e9df28d154ec65b99757dff45603",
+  "display_name": "Item Tags",
+  "display_author": "Ellz",
+  "display_description": "Tags over item icons to aid recognition."
+
+}

--- a/plugins/menu-rgb.json
+++ b/plugins/menu-rgb.json
@@ -1,0 +1,9 @@
+{
+  "repository_owner": "crispybittie",
+  "repository_name": "MenuRGB",
+  "asset_sha": "sha256:63cdcc69c6478ccc43eb28c1eeded5c065b00d0af4399e882e6a4ccf9d011fd4",
+  "display_name": "MenuRGB",
+  "display_author": "Ellz",
+  "display_description": "Customizable text colors for context menu actions."
+
+}


### PR DESCRIPTION
Item Tags adds tags over item icons for easier recognition of certain items, such as logs, roots, potions, and hard-to-see items like bandit masks or coronium gear. It is customisable in color and preset categories, and allows basic differentiation between bank and inventory tags.

MenuRGB permits customisation of text color for specific actions in the context menu to maximise click accuracy without controversial context menu swaps. You can specify a catchall action like Deposit All, or you can specify an object, such as Withdraw 10|Leather, for fine-tuning. It comes with space for two separate groups of inputs, allowing two different color schemes for as many actions as you need.